### PR TITLE
Retry option fixes

### DIFF
--- a/common/src/main/java/org/apache/cassandra/diff/AstraClusterProvider.java
+++ b/common/src/main/java/org/apache/cassandra/diff/AstraClusterProvider.java
@@ -7,10 +7,6 @@ import java.util.function.Function;
 
 import com.datastax.driver.core.Cluster;
 
-import static org.apache.cassandra.diff.ContactPointsClusterProvider.PASSWORD_KEY;
-import static org.apache.cassandra.diff.ContactPointsClusterProvider.USERNAME_KEY;
-import static org.apache.cassandra.diff.ContactPointsClusterProvider.getEnv;
-
 public class AstraClusterProvider implements ClusterProvider {
     private static final String SECURE_CONNECT_BUNDLE_KEY = "secure_connect_bundle";
     private static final String CLUSTER_NAME_KEY = "cluster_name";
@@ -29,8 +25,8 @@ public class AstraClusterProvider implements ClusterProvider {
     public void initialize(Map<String, String> conf, String identifier) {
         secureConnectBundle = throwIfMissing(SECURE_CONNECT_BUNDLE_KEY, conf::get);
         clusterName = throwIfMissing(CLUSTER_NAME_KEY, conf::get);
-        username = throwIfMissing(USERNAME_KEY, k -> getEnv(identifier, k));
-        password = throwIfMissing(PASSWORD_KEY, k -> getEnv(identifier, k));
+        username = throwIfMissing(USERNAME_KEY, conf::get);
+        password = throwIfMissing(PASSWORD_KEY, conf::get);
     }
 
     @Override

--- a/common/src/main/java/org/apache/cassandra/diff/ClusterProvider.java
+++ b/common/src/main/java/org/apache/cassandra/diff/ClusterProvider.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import com.datastax.driver.core.Cluster;
 
 public interface ClusterProvider extends Serializable {
+    String PREFIX = "diff.cluster";
+    String USERNAME_KEY = "cql_user";
+    String PASSWORD_KEY = "cql_password";
     String CLUSTER_PROVIDER_CLASS = "impl";
 
     void initialize(Map<String, String> conf, String identifier);

--- a/common/src/main/java/org/apache/cassandra/diff/ContactPointsClusterProvider.java
+++ b/common/src/main/java/org/apache/cassandra/diff/ContactPointsClusterProvider.java
@@ -24,9 +24,7 @@ import java.util.Map;
 import com.datastax.driver.core.Cluster;
 
 public class ContactPointsClusterProvider implements ClusterProvider {
-    private static final String PREFIX = "diff.cluster";
-    protected static final String USERNAME_KEY = "cql_user";
-    protected static final String PASSWORD_KEY = "cql_password";
+
     private static final String CONTACT_POINTS_KEY = "contact_points";
     private static final String PORT_KEY = "port";
     private static final String CLUSTER_KEY = "name";

--- a/common/src/main/java/org/apache/cassandra/diff/ExponentialRetryStrategyProvider.java
+++ b/common/src/main/java/org/apache/cassandra/diff/ExponentialRetryStrategyProvider.java
@@ -1,5 +1,6 @@
 package org.apache.cassandra.diff;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Preconditions;
@@ -11,7 +12,7 @@ import static org.apache.cassandra.diff.ExponentialRetryStrategyProvider.Exponen
 import static org.apache.cassandra.diff.ExponentialRetryStrategyProvider.ExponentialRetryStrategy.TOTAL_DELAY_MS_KEY;
 
 public class ExponentialRetryStrategyProvider extends RetryStrategyProvider {
-    public ExponentialRetryStrategyProvider(JobConfiguration.RetryOptions retryOptions) {
+    public ExponentialRetryStrategyProvider(Map<String,String> retryOptions) {
         super(retryOptions);
     }
 

--- a/common/src/main/java/org/apache/cassandra/diff/JobConfiguration.java
+++ b/common/src/main/java/org/apache/cassandra/diff/JobConfiguration.java
@@ -92,12 +92,8 @@ public interface JobConfiguration extends Serializable {
      * Note that it is different than cassandra java driver's {@link com.datastax.driver.core.policies.RetryPolicy},
      * which is evaluated at the Netty worker threads.
      */
-    RetryOptions retryOptions();
+    Map<String, String> retryOptions();
 
     Map<String, String> clusterConfig(String identifier);
-
-    // Just an alias
-    public static class RetryOptions extends HashMap<String, String> {
-    }
 
 }

--- a/common/src/main/java/org/apache/cassandra/diff/RetryStrategyProvider.java
+++ b/common/src/main/java/org/apache/cassandra/diff/RetryStrategyProvider.java
@@ -3,14 +3,16 @@ package org.apache.cassandra.diff;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
+
 /**
  * Provides new RetryStrategy instances.
  * Use abstract class instead of interface in order to retain the referece to retryOptions;
  */
 public abstract class RetryStrategyProvider {
-    protected final JobConfiguration.RetryOptions retryOptions;
+    protected final Map<String,String> retryOptions;
 
-    public RetryStrategyProvider(JobConfiguration.RetryOptions retryOptions) {
+    public RetryStrategyProvider(Map<String,String> retryOptions) {
         this.retryOptions = retryOptions;
     }
 
@@ -26,21 +28,29 @@ public abstract class RetryStrategyProvider {
     /**
      * Create a RetryStrategyProvider based on {@param retryOptions}.
      */
-    public static RetryStrategyProvider create(JobConfiguration.RetryOptions retryOptions) {
+    public static RetryStrategyProvider create(Map<String,String> retryOptions) {
         try {
+            if (retryOptions == null || retryOptions.get(IMPLEMENTATION_KEY) == null) {
+                logger.info("No retry options were specified, using the default NoRetry provider");
+                return createDefaultRetryStrategyProvider(retryOptions);
+            }
             String implClass = retryOptions.get(IMPLEMENTATION_KEY);
             return (RetryStrategyProvider) Class.forName(implClass)
-                                                .getConstructor(JobConfiguration.RetryOptions.class)
+                                                .getConstructor(Map.class)
                                                 .newInstance(retryOptions);
         } catch (Exception ex) {
-            logger.warn("Unable to create RetryStrategyProvider. Use the default provider, NoRetry.", ex);
-
-            return new RetryStrategyProvider(retryOptions) {
-                @Override
-                public RetryStrategy get() {
-                    return RetryStrategy.NoRetry.INSTANCE;
-                }
-            };
+            logger.warn("Using the default NoRetry provider due to an exception trying to create the requested RetryStrategyProvider", ex);
+            return createDefaultRetryStrategyProvider(retryOptions);
         }
     }
+
+    private static RetryStrategyProvider createDefaultRetryStrategyProvider(Map<String,String> retryOptions) {
+        return new RetryStrategyProvider(retryOptions) {
+            @Override
+            public RetryStrategy get() {
+                return RetryStrategy.NoRetry.INSTANCE;
+            }
+        };
+    }
+
 }

--- a/common/src/main/java/org/apache/cassandra/diff/YamlJobConfiguration.java
+++ b/common/src/main/java/org/apache/cassandra/diff/YamlJobConfiguration.java
@@ -21,12 +21,7 @@ package org.apache.cassandra.diff;
 
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
@@ -47,7 +42,7 @@ public class YamlJobConfiguration implements JobConfiguration {
     public Map<String, Map<String, String>> cluster_config;
     public String specific_tokens = null;
     public String disallowed_tokens = null;
-    public RetryOptions retry_options;
+    public Map<String,String> retry_options;
 
     public static YamlJobConfiguration load(InputStream inputStream) {
         Yaml yaml = new Yaml(new CustomClassLoaderConstructor(YamlJobConfiguration.class,
@@ -103,7 +98,7 @@ public class YamlJobConfiguration implements JobConfiguration {
         return metadata_options;
     }
 
-    public RetryOptions retryOptions() {
+    public Map<String, String> retryOptions() {
         return retry_options;
     }
 
@@ -138,6 +133,7 @@ public class YamlJobConfiguration implements JobConfiguration {
                ", consistency_level='" + consistency_level + '\'' +
                ", metadata_options=" + metadata_options +
                ", cluster_config=" + cluster_config +
+               ", retry_options=" + retry_options +
                '}';
     }
 

--- a/common/src/test/java/org/apache/cassandra/diff/ExponentialRetryStrategyTest.java
+++ b/common/src/test/java/org/apache/cassandra/diff/ExponentialRetryStrategyTest.java
@@ -1,5 +1,7 @@
 package org.apache.cassandra.diff;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -46,7 +48,7 @@ public class ExponentialRetryStrategyTest {
 
     @Test
     public void testToString() {
-        ExponentialRetryStrategyProvider provider = new ExponentialRetryStrategyProvider(new JobConfiguration.RetryOptions());
+        ExponentialRetryStrategyProvider provider = new ExponentialRetryStrategyProvider(retryOptions(1000,1800000 ));
         String output = provider.get().toString();
         Assert.assertEquals("ExponentialRetryStrategy(baseDelayMs: 1000, totalDelayMs: 1800000, currentAttempts: 0)",
                             output);
@@ -91,8 +93,8 @@ public class ExponentialRetryStrategyTest {
         }
     }
 
-    private JobConfiguration.RetryOptions retryOptions(long baseDelayMs, long totalDelayMs) {
-        return new JobConfiguration.RetryOptions() {{
+    private Map<String,String> retryOptions(long baseDelayMs, long totalDelayMs) {
+        return new LinkedHashMap<String,String>() {{
             put(ExponentialRetryStrategy.BASE_DELAY_MS_KEY, String.valueOf(baseDelayMs));
             put(ExponentialRetryStrategy.TOTAL_DELAY_MS_KEY, String.valueOf(totalDelayMs));
         }};

--- a/common/src/test/java/org/apache/cassandra/diff/YamlJobConfigurationTest.java
+++ b/common/src/test/java/org/apache/cassandra/diff/YamlJobConfigurationTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 
 import org.hamcrest.CoreMatchers;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.apache.cassandra.diff.ExponentialRetryStrategyProvider.ExponentialRetryStrategy;
 
 public class YamlJobConfigurationTest {
@@ -16,7 +19,7 @@ public class YamlJobConfigurationTest {
             Assert.assertTrue("Keyspace segment is not loaded correctly", kt.keyspace.contains("ks"));
             Assert.assertTrue("Table segment is not loaded correctly", kt.table.contains("tb"));
         });
-        JobConfiguration.RetryOptions retryOptions = jobConfiguration.retryOptions();
+        Map<String,String> retryOptions = jobConfiguration.retryOptions();
         Assert.assertNotNull("retry_options not defined", retryOptions);
         Assert.assertNotNull("impl not defined", retryOptions.get(ExponentialRetryStrategyProvider.IMPLEMENTATION_KEY));
         Assert.assertNotNull("base_delay_ms not defined", retryOptions.get(ExponentialRetryStrategy.BASE_DELAY_MS_KEY));
@@ -48,7 +51,7 @@ public class YamlJobConfigurationTest {
         Assert.assertThat(provider.get(), CoreMatchers.instanceOf(ExponentialRetryStrategy.class));
 
         // empty retry option leads to NoRetry strategy
-        provider = RetryStrategyProvider.create(new JobConfiguration.RetryOptions());
+        provider = RetryStrategyProvider.create(new LinkedHashMap());
         Assert.assertThat(provider.get(), CoreMatchers.sameInstance(RetryStrategy.NoRetry.INSTANCE));
 
         // null retry option leads to NoRetry strategy

--- a/spark-job/src/main/java/org/apache/cassandra/diff/DiffJob.java
+++ b/spark-job/src/main/java/org/apache/cassandra/diff/DiffJob.java
@@ -65,6 +65,7 @@ public class DiffJob {
         JavaSparkContext sc = new JavaSparkContext(spark.sparkContext());
         String configFile = SparkFiles.get(args[0]);
         YamlJobConfiguration configuration = YamlJobConfiguration.load(new FileInputStream(configFile));
+        logger.info("Configuration: " + configuration.toString());
         DiffJob diffJob = new DiffJob();
         diffJob.run(configuration, sc);
         spark.stop();

--- a/spark-job/src/test/java/org/apache/cassandra/diff/AbstractMockJobConfiguration.java
+++ b/spark-job/src/test/java/org/apache/cassandra/diff/AbstractMockJobConfiguration.java
@@ -78,7 +78,7 @@ public abstract class AbstractMockJobConfiguration implements JobConfiguration {
     }
 
     @Override
-    public RetryOptions retryOptions() {
+    public Map<String, String> retryOptions() {
         throw uoe;
     }
 }


### PR DESCRIPTION
Removed RetryOptions alias and simply declared it as a map to simplify yaml parsing. 

I also made a slight change to the RetryStrategyProvider instantiation logic, which was handling the legitimate case of no retry options specified through the generic exception handling logic (null retry options resulted in a NullPointerException). It now checks for null or missing "impl" class first, and in that case it just creates the default strategy and logs an info message. Any other exception is still dealt with as before, also resulting in the default strategy being instantiated.